### PR TITLE
shellcheck false positive: wgetOptions must not be in quotes

### DIFF
--- a/victron-venus-os-install.sh
+++ b/victron-venus-os-install.sh
@@ -38,7 +38,7 @@ for url in \
     https://raw.githubusercontent.com/christian1980nrw/Victron-ESS__AVM-Fritz-DECT200-210__Spotmarket-Switcher/main/data/etc/Spotmarket-Switcher/controller.sh
 do
     echo "I: Downloading '$(basename "$url")'"
-    if ! wget "$wgetOptions" "$url"; then
+    if ! wget $wgetOptions "$url"; then
         echo "E: Download of '$(basename "$url")' failed."
         exit 1
     fi
@@ -49,7 +49,7 @@ chmod +x ./controller.sh
 url=https://raw.githubusercontent.com/christian1980nrw/Victron-ESS__AVM-Fritz-DECT200-210__Spotmarket-Switcher/main/data/etc/Spotmarket-Switcher/service/run
 echo "I: Downloading 'run' script to service subdirectory"
 cd service
-if ! wget "$wgetOptions" $url; then
+if ! wget $wgetOptions $url; then
   echo "E: Failure downloading run script from '$url'."
   exit 1
 fi


### PR DESCRIPTION
The shellcheck script is warning is about something that we want to happen. I suggest to have the shellcheck only optional if that cannot be fixed by some options, say be adding `|| true`.